### PR TITLE
Fix circular reference able to cause a stackoverflow

### DIFF
--- a/assets/prefabs/easterEgg.prefab
+++ b/assets/prefabs/easterEgg.prefab
@@ -1,6 +1,6 @@
 {
   "StructureTemplate": {
-    "type": "ShatteredPlanes:easterEgg"
+    "type": "ShatteredPlanes:easterEggST"
   },
   "SpawnBlockRegions": {
     "regionsToFill": [


### PR DESCRIPTION
This was sneaky as it didn't happen _unless_ StructureTemplates the module was also enabled, but that's only a soft dependency. There's an easter egg ST included, but it doesn't actually get used. If the ST module was enabled something got stuck with the `"type": "ShatteredPlanes:easterEgg"` reference _inside_ `easterEgg.prefab`  - which could be taken as a reference to that prefab itself over and over leading to a stackoverflow.  See https://github.com/MovingBlocks/Terasology/issues/3739

Simply giving the type prefab a distinct name fixes this. So now it is `ShatteredPlanes:easterEggST`